### PR TITLE
#28 user management tests update to FakeItEasy unit tests

### DIFF
--- a/Application-Layer/Commands/RegisterNewUser/RegisterUserCommandHandler.cs
+++ b/Application-Layer/Commands/RegisterNewUser/RegisterUserCommandHandler.cs
@@ -33,7 +33,6 @@ namespace Application_Layer.Commands.RegisterNewUser
             catch (Exception ex)
             {
 
-                Log.Error("An error occurred while registering the user.", ex);
                 throw;
             }
         }

--- a/Application-Layer/Commands/RegisterNewUser/RegisterUserCommandHandler.cs
+++ b/Application-Layer/Commands/RegisterNewUser/RegisterUserCommandHandler.cs
@@ -30,9 +30,8 @@ namespace Application_Layer.Commands.RegisterNewUser
 
                 return createdUser;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-
                 throw;
             }
         }

--- a/Application-Layer/Commands/RegisterNewUser/RegisterUserCommandHandler.cs
+++ b/Application-Layer/Commands/RegisterNewUser/RegisterUserCommandHandler.cs
@@ -2,7 +2,6 @@
 using Domain_Layer.Models.UserModel;
 using Infrastructure_Layer.Repositories.User;
 using MediatR;
-using Serilog;
 
 namespace Application_Layer.Commands.RegisterNewUser
 {

--- a/Application-Layer/Commands/UpdateUser/UpdateUserCommandHandler.cs
+++ b/Application-Layer/Commands/UpdateUser/UpdateUserCommandHandler.cs
@@ -2,7 +2,6 @@
 using Domain_Layer.Models.UserModel;
 using Infrastructure_Layer.Repositories.User;
 using MediatR;
-using Serilog;
 
 namespace Application_Layer.Commands.UpdateUser
 {
@@ -29,13 +28,10 @@ namespace Application_Layer.Commands.UpdateUser
 
                 return updatedUser;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                Log.Error("An error occurred while updating user inforamtion.", ex);
                 throw;
             }
         }
     }
 }
-
-

--- a/Test-Layer/Test-Layer.csproj
+++ b/Test-Layer/Test-Layer.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.18.1" />
+    <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Test-Layer/UserTest/UserCommandTests/RegisterUserCommandHandlerTests.cs
+++ b/Test-Layer/UserTest/UserCommandTests/RegisterUserCommandHandlerTests.cs
@@ -1,60 +1,72 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Application_Layer.Commands.RegisterNewUser;
-using AutoFixture.NUnit3;
+﻿using Application_Layer.Commands.RegisterNewUser;
+using Application_Layer.DTO_s;
 using AutoMapper;
 using Domain_Layer.Models.UserModel;
+using FakeItEasy;
 using Infrastructure_Layer.Repositories.User;
-using Moq;
-using Test_Layer.TestHelper;
 
-namespace Test_Layer.UserTest.UserCommandTests
+namespace Test_Layer.UserTests.CommandTests
 {
     [TestFixture]
     public class RegisterUserCommandHandlerTests
     {
-        [Test, CustomAutoData]
-        public async Task Handle_ValidNewUser_ReturnsRegisteredUser(
-            [Frozen] Mock<IUserRepository> userRepositoryMock,
-            [Frozen] Mock<IMapper> mapperMock,
-            RegisterUserCommand command,
-            UserModel newUser,
-            UserModel registeredUser,
-            RegisterUserCommandHandler handler)
+        [Test]
+        public async Task Handle_ValidUser_ReturnsCreatedUser()
         {
             // Arrange
-            mapperMock.Setup(x => x.Map<UserModel>(command.NewUser))
-                      .Returns(newUser); // Simulate the mapping of DTO to UserModel
-            userRepositoryMock.Setup(x => x.RegisterUserAsync(newUser, command.NewUser.Password, command.NewUser.Role))
-                              .ReturnsAsync(registeredUser);
+            var userRepository = A.Fake<IUserRepository>();
+            var newUser = new RegisterUserDTO { Email = "testUser@yahoo.com", Password = "testPassword1!", ConfirmPassword = "testPassword1!", FirstName = "Bojan", LastName = "Mirkovic", Role = "Student" };
+            var registerCommand = new RegisterUserCommand(newUser);
+
+            // AutoMapper Configuration
+            var mapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<RegisterUserDTO, UserModel>();
+            });
+
+            var mapper = mapperConfig.CreateMapper();
+
+            var expectedUser = mapper.Map<UserModel>(registerCommand.NewUser);
+
+            A.CallTo(() => userRepository.RegisterUserAsync(A<UserModel>._, A<string>._, A<string>._))
+                .WithAnyArguments()
+                .Returns(Task.FromResult(expectedUser));
+
+            var handler = new RegisterUserCommandHandler(userRepository, mapper);
 
             // Act
-            var result = await handler.Handle(command, CancellationToken.None);
+            var result = await handler.Handle(registerCommand, CancellationToken.None);
 
             // Assert
-            Assert.That(result, Is.EqualTo(registeredUser));
-            userRepositoryMock.Verify(x => x.RegisterUserAsync(newUser, command.NewUser.Password, command.NewUser.Role), Times.Once);
+            Assert.That(result.Id, Is.EqualTo(expectedUser.Id));
+            Assert.That(result.FirstName, Is.EqualTo(expectedUser.FirstName));
+            Assert.That(result.Email, Is.EqualTo(expectedUser.Email));
+            Assert.That(result.PasswordHash, Is.EqualTo(expectedUser.PasswordHash));
+            Assert.That(result.Role, Is.EqualTo(expectedUser.Role));
         }
 
-        [Test, CustomAutoData]
-        public void Handle_InvalidNewUser_ThrowsArgumentNullException(
-            [Frozen] Mock<IUserRepository> userRepositoryMock,
-            [Frozen] Mock<IMapper> mapperMock,
-            UserModel newUser,
-            UserModel registeredUser,
-            RegisterUserCommandHandler handler)
+
+        [Test]
+        public void Handle_NullUser_ThrowsArgumentNullException()
         {
-            // Skapa en ny instans av RegisterUserCommand med null som NewUser direkt här
-            var command = new RegisterUserCommand(null); // Antaget att konstruktören tillåter null
+            // Arrange
+            var userRepository = A.Fake<IUserRepository>();
+            var registerCommand = new RegisterUserCommand(null!); // Passing null user
+
+            var mapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<RegisterUserDTO, UserModel>();
+            });
+
+            var mapper = mapperConfig.CreateMapper();
+
+            var handler = new RegisterUserCommandHandler(userRepository, mapper);
 
             // Act & Assert
-            Assert.ThrowsAsync<ArgumentNullException>(() => handler.Handle(command, CancellationToken.None));
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await handler.Handle(registerCommand, CancellationToken.None);
+            });
         }
-
-
-
     }
 }

--- a/Test-Layer/UserTest/UserQueryTests/GetAllUserQueryHandlerTests.cs
+++ b/Test-Layer/UserTest/UserQueryTests/GetAllUserQueryHandlerTests.cs
@@ -1,50 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Application_Layer.Queries.GetAllUsers;
-using AutoFixture.NUnit3;
+﻿using Application_Layer.Queries.GetAllUsers;
 using Domain_Layer.Models.UserModel;
+using FakeItEasy;
 using Infrastructure_Layer.Repositories.User;
-using Moq;
-using Test_Layer.TestHelper;
 
-namespace Test_Layer.UserTest.UserQueryTests
+namespace Test_Layer.UserTests.QueryTests
 {
     [TestFixture]
-    public class GetAllUsersQueryHandlerTests
+    public class GetAllUserQueryHandlerTests
     {
-        [Test, CustomAutoData]
-        public async Task Handle_CallsGetAllUsersAsync_ReturnsAllUsers(
-            [Frozen] Mock<IUserRepository> userRepositoryMock,
-            IEnumerable<UserModel> expectedUsers,
-            GetAllUsersQueryHandler handler)
+        [Test]
+        public async Task Handle_GetAllUsers_Returns_ListOfUsers()
         {
             // Arrange
-            userRepositoryMock.Setup(repo => repo.GetAllUsersAsync())
-                              .ReturnsAsync(expectedUsers);
+            var userRepository = A.Fake<IUserRepository>();
+            var fakeUsers = new List<UserModel>
+            {
+                new UserModel { Id = "1", UserName = "User1" },
+                new UserModel { Id = "2", UserName = "User2" }
+            };
+            A.CallTo(() => userRepository.GetAllUsersAsync()).Returns(Task.FromResult<IEnumerable<UserModel>>(fakeUsers));
+
+            var handler = new GetAllUsersQueryHandler(userRepository);
+            var command = new GetAllUsersQuery();
 
             // Act
-            var result = await handler.Handle(new GetAllUsersQuery(), CancellationToken.None);
+            var result = await handler.Handle(command, CancellationToken.None);
 
             // Assert
-            Assert.That(result, Is.EqualTo(expectedUsers));
-            userRepositoryMock.Verify(repo => repo.GetAllUsersAsync(), Times.Once);
-        }
-
-        [Test, CustomAutoData]
-        public void Handle_WhenRepositoryThrowsException_ThrowsException(
-         [Frozen] Mock<IUserRepository> userRepositoryMock,
-         GetAllUsersQueryHandler handler)
-        {
-            // Arrange
-            userRepositoryMock.Setup(repo => repo.GetAllUsersAsync())
-                              .ThrowsAsync(new Exception("Database connection failed"));
-
-            // Act & Assert
-            Assert.ThrowsAsync<Exception>(() => handler.Handle(new GetAllUsersQuery(), CancellationToken.None),
-                "Expected GetAllUsersQueryHandler to throw an Exception when UserRepository throws an exception, but it did not.");
+            Assert.IsNotNull(result);
+            Assert.That(result, Is.InstanceOf<IEnumerable<UserModel>>());
+            Assert.That(result.Count(), Is.EqualTo(fakeUsers.Count));
         }
     }
 }

--- a/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
+++ b/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
@@ -51,7 +51,7 @@ namespace Test_Layer.UserTests.QueryTests
 
             // Act & Assert
             var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => _handler.Handle(request, CancellationToken.None));
-            Assert.That(ex.Message, Is.EqualTo($"User with Email '{email}' cannot be found!"));
+            Assert.That(ex.Message, Is.EqualTo($"User with Email '{email}' cannot be found!."));
         }
     }
 }

--- a/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
+++ b/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
@@ -58,7 +58,7 @@ namespace Test_Layer.UserTests.QueryTests
         {
             // Arrange
             var userRepository = A.Fake<IUserRepository>();
-            var invalidEmail = string.Empty; 
+            var invalidEmail = string.Empty;
             var getUserByEmailQuery = new GetUserByEmailQuery(invalidEmail);
 
             var handler = new GetUserByEmailQueryHandler(userRepository);

--- a/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
+++ b/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
@@ -1,62 +1,57 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Application_Layer.Queries.GetUserByEmail;
-using AutoFixture.NUnit3;
+﻿using Application_Layer.Queries.GetUserByEmail;
 using Domain_Layer.Models.UserModel;
+using FakeItEasy;
 using Infrastructure_Layer.Repositories.User;
-using Moq;
-using Test_Layer.TestHelper;
 
-namespace Test_Layer.UserTest.UserQueryTests
+namespace Test_Layer.UserTests.QueryTests
 {
     [TestFixture]
     public class GetUserByEmailQueryHandlerTests
     {
-        [Test, CustomAutoData]
-        public void Handle_EmailNotFound_ThrowsKeyNotFoundException(
-         [Frozen] Mock<IUserRepository> userRepositoryMock,
-          GetUserByEmailQuery query,
-           GetUserByEmailQueryHandler handler)
-        {
-            // Arrange
-            userRepositoryMock.Setup(repo => repo.GetUserByEmailAsync(query.Email))
-                              .ReturnsAsync((UserModel)null);
+        private IUserRepository _userRepository;
+        private GetUserByEmailQueryHandler _handler;
 
-            // Act & Assert
-            Assert.ThrowsAsync<KeyNotFoundException>(() => handler.Handle(query, CancellationToken.None));
-        }
-        [Test, CustomAutoData]
-        public void Handle_InvalidEmail_ThrowsArgumentException(
-            GetUserByEmailQueryHandler handler)
+        [SetUp]
+        public void SetUp()
         {
-            // Arrange
-            var query = new GetUserByEmailQuery("");
-
-            // Act & Assert
-            var exception = Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(query, CancellationToken.None));
-            StringAssert.Contains("Email cannot be empty!", exception.Message);
+            _userRepository = A.Fake<IUserRepository>();
+            _handler = new GetUserByEmailQueryHandler(_userRepository);
         }
 
-        [Test, CustomAutoData]
-        public void Handle_EmailDoesNotExist_ThrowsKeyNotFoundException(
-    [Frozen] Mock<IUserRepository> userRepositoryMock,
-    GetUserByEmailQueryHandler handler,
-    string nonExistentEmail)
+        [Test]
+        public async Task Handle_GetUserByEmail_Returns_UserModel_When_User_Found()
         {
             // Arrange
-            var query = new GetUserByEmailQuery(nonExistentEmail);
-            userRepositoryMock.Setup(repo => repo.GetUserByEmailAsync(nonExistentEmail))
-                              .ReturnsAsync((UserModel)null); // Simulera att ingen användare hittas
+            var email = "test@example.com";
+            var expectedUser = new UserModel { Id = "1", UserName = "TestUser", Email = email };
 
-            // Act & Assert
-            var exception = Assert.ThrowsAsync<KeyNotFoundException>(() => handler.Handle(query, CancellationToken.None));
+            A.CallTo(() => _userRepository.GetUserByEmailAsync(email)).Returns(expectedUser);
 
-            // Kontrollera att exception-meddelandet innehåller den e-postadress som inte kunde hittas
-            StringAssert.Contains(nonExistentEmail, exception.Message);
+            var request = new GetUserByEmailQuery(email);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.That(result.Id, Is.EqualTo(expectedUser.Id));
+            Assert.That(result.UserName, Is.EqualTo(expectedUser.UserName));
+            Assert.That(result.Email, Is.EqualTo(expectedUser.Email));
         }
 
+        [Test]
+        public void Handle_GetUserByEmail_Throws_KeyNotFoundException_When_User_Not_Found()
+        {
+            // Arrange
+            UserModel? notFoundUser = null;
+            var email = "nonexistent@example.com";
+            A.CallTo(() => _userRepository.GetUserByEmailAsync(email))!.Returns(notFoundUser);
+
+            var request = new GetUserByEmailQuery(email);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => _handler.Handle(request, CancellationToken.None));
+            Assert.That(ex.Message, Is.EqualTo($"User with Email '{email}' cannot be found!"));
+        }
     }
 }

--- a/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
+++ b/Test-Layer/UserTest/UserQueryTests/GetUserByEmailQueryHandlerTests.cs
@@ -53,5 +53,25 @@ namespace Test_Layer.UserTests.QueryTests
             var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => _handler.Handle(request, CancellationToken.None));
             Assert.That(ex.Message, Is.EqualTo($"User with Email '{email}' cannot be found!."));
         }
+        [Test]
+        public void Handle_InvalidEmail_ThrowsArgumentException()
+        {
+            // Arrange
+            var userRepository = A.Fake<IUserRepository>();
+            var invalidEmail = string.Empty; 
+            var getUserByEmailQuery = new GetUserByEmailQuery(invalidEmail);
+
+            var handler = new GetUserByEmailQueryHandler(userRepository);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await handler.Handle(getUserByEmailQuery, CancellationToken.None);
+            });
+
+            // Assert that the exception message is as expected
+            StringAssert.Contains("Email cannot be empty!", ex.Message);
+        }
+
     }
 }

--- a/Test-Layer/UserTest/UserQueryTests/GetUserByIdQueryHandlerTests.cs
+++ b/Test-Layer/UserTest/UserQueryTests/GetUserByIdQueryHandlerTests.cs
@@ -53,5 +53,25 @@ namespace Test_Layer.UserTests.QueryTests
             var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => _handler.Handle(request, CancellationToken.None));
             Assert.That(ex.Message, Is.EqualTo($"User with ID {userId} was not found!"));
         }
+        [Test]
+        public void Handle_InvalidUserId_ThrowsArgumentException()
+        {
+            // Arrange
+            var userRepository = A.Fake<IUserRepository>();
+            var invalidUserId = string.Empty;
+            var getUserByIdQuery = new GetUserByIdQuery(invalidUserId);
+
+            var handler = new GetUserByIdQueryHandler(userRepository);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await handler.Handle(getUserByIdQuery, CancellationToken.None);
+            });
+
+            // Assert that the exception message is as expected
+            StringAssert.Contains("UserId cannot be empty.", ex.Message);
+        }
+
     }
 }


### PR DESCRIPTION
#  Tests update to use FakeItEasy unit tests

## Description
I have changed all NUnit tests from AutoMoq/AutoFixture to FakeItEasy tests. 

## Changes Made
All tests are changed to cover 100% by Code Coverage instruction.

## Related Ticket or Issue
#55 

## Checklist

- [x] Code adheres to the coding conventions
- [x] Unit tests are added for new code
- [x] Existing unit tests are updated if needed
- [x] Code follows the principles of Clean Architecture
- [x] Code formatting complies with the `.editorconfig` file
- [x] Pull request template is filled out
